### PR TITLE
Upgrade json, restforce, and webmock to latest versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To run the tests locally:
 ```
 cp  env_setup-example.sh env_setup.sh
 ```
-* Setup all the params in env_setup. USERNAME, PASSWORD and TOKEN are your salesforce account credentials. You can get those by [registering for a free developer account](https://developer.salesforce.com/signup). You might need to [reset your security token](https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm) to put it to TOKEN variable. CLIENT_ID and CLIENT_SECRET belong to your Salesforce connected app. You can create one by following the steps outlined in [the tutorial](https://help.salesforce.com/apex/HTViewHelpDoc?id=connected_app_create.htm). Make sure you check the 'api' permission.
+* Setup all the params in env_setup. USERNAME, PASSWORD and TOKEN are your salesforce account credentials. You can get those by [registering for a free developer account](https://developer.salesforce.com/signup). Note that if you are using zsh then `USERNAME` is a reserved environment variable and cannot be modified. You might need to [reset your security token](https://help.salesforce.com/apex/HTViewHelpDoc?id=user_security_token.htm) to put it to TOKEN variable. CLIENT_ID and CLIENT_SECRET belong to your Salesforce connected app. You can create one by following the steps outlined in [the tutorial](https://help.salesforce.com/apex/HTViewHelpDoc?id=connected_app_create.htm). Make sure you check the 'api' permission.
 * Run the env_setup
 ```
 . env_setup.sh

--- a/lib/salesforce_bulk_query/connection.rb
+++ b/lib/salesforce_bulk_query/connection.rb
@@ -131,7 +131,7 @@ module SalesforceBulkQuery
           q = @client.query(soql)
           return q.size
         end
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
         @logger.warn "Timeout getting count: #{soql}. Error: #{e}. Taking it as failed verification" if @logger
         return nil
       end

--- a/lib/salesforce_bulk_query/query.rb
+++ b/lib/salesforce_bulk_query/query.rb
@@ -180,7 +180,7 @@ module SalesforceBulkQuery
       begin
         min_created_resp = @connection.client.query("SELECT #{@date_field} FROM #{@sobject} ORDER BY #{@date_field} LIMIT 1")
         min_created_resp.each {|s| min_created = s[@date_field.to_sym]}
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
         @logger.warn "Timeout getting the oldest object for #{@sobject}. Error: #{e}. Using the default value" if @logger
         min_created = DEFAULT_MIN_CREATED
       rescue Faraday::ClientError => e

--- a/salesforce_bulk_query.gemspec
+++ b/salesforce_bulk_query.gemspec
@@ -8,24 +8,24 @@ Gem::Specification.new do |s|
   s.authors = ['Petr Cvengros']
   s.email = ['petr.cvengros@gooddata.com']
 
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.5'
 
   s.homepage = 'https://github.com/cvengros/salesforce_bulk_query'
   s.summary = %q{Downloading data from Salesforce Bulk API made easy and scalable.}
   s.description = %q{A library for downloading data from Salesforce Bulk API. We only focus on querying, other operations of the API aren't supported. Designed to handle a lot of data.}
   s.license = 'BSD'
 
-  s.add_dependency 'json', '<= 2'
+  s.add_dependency 'json', '~> 2.0'
   s.add_dependency 'xml-simple', '~> 1.1'
 
   s.add_development_dependency 'multi_json', '~> 1.9'
-  s.add_development_dependency 'restforce', '~>1.4'
+  s.add_development_dependency 'restforce', '~> 5.0'
   s.add_development_dependency 'rspec', '~>2.14'
   s.add_development_dependency 'pry', '~>0.9'
   s.add_development_dependency 'pry-stack_explorer', '~>0.4' if RUBY_PLATFORM != 'java'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'coveralls', '~> 0.7'
-  s.add_development_dependency 'webmock', '~> 1.20'
+  s.add_development_dependency 'webmock', '~> 3.0'
 
   s.files = `git ls-files`.split($/)
   s.require_paths = ['lib']


### PR DESCRIPTION
The versions of each of these had fallen a reasonable way behind mainline, which could cause issues when trying to depend on this code in more up-to-date codebases.

There were 2 tests that I updated to make them more robust. The timeout one I made the queries explicit that were being mocked. There was another test that only worked up to the year 2020, so updating that to work until the year 3000.

The newer versions of Faraday now use a ConnectionFailed error to indicate a timeout when opening the connection (https://github.com/lostisland/faraday/issues/718), so updated accordingly.

Restforce 5 requires ruby 2.5, so updated that requirement as well. Also updated the tests to point to the latest version of the API at time of writing.

In terms of testing done, I've run all the specs and they're green. I've also run this branch in my app and functionality is as before.